### PR TITLE
Bump Arrow to 1.0.1

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CMAKE_VERSION: '3.17.3'
-  ARROW_VERSION: '1.0.0'
+  ARROW_VERSION: '1.0.1'
 
 jobs:
   python:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,7 @@ jobs:
     container: quay.io/pypa/manylinux2014_x86_64:latest
     env:
       CMAKE_VERSION: '3.17.3'
-      ARROW_VERSION: '1.0.0'
+      ARROW_VERSION: '1.0.1'
       CPYTHON_VERSION: 'cp35-cp35m'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  ARROW_VERSION: '1.0.0'
+  ARROW_VERSION: '1.0.1'
 
 jobs:
   cpp:

--- a/codegen/python/setup.py
+++ b/codegen/python/setup.py
@@ -119,12 +119,12 @@ setup(
     install_requires=[
         'numpy >= 1.14',
         'pandas',
-        'pyarrow == 1.0.0',
+        'pyarrow == 1.0.1',
     ],
     setup_requires=[
         'cython',
         'numpy',
-        'pyarrow == 1.0.0',
+        'pyarrow == 1.0.1',
         'plumbum'
     ],
     classifiers=[

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -124,12 +124,12 @@ setup(
     install_requires=[
         'numpy >= 1.14',
         'pandas',
-        'pyarrow == 1.0.0',
+        'pyarrow == 1.0.1',
     ],
     setup_requires=[
         'cython',
         'numpy',
-        'pyarrow == 1.0.0',
+        'pyarrow == 1.0.1',
         'plumbum',
         'pytest-runner'
     ],


### PR DESCRIPTION
This should fix the macOS Arrow install CI failures.