### PR TITLE
Add cmdIn_lastIdx to sensitivity list in BufferWriterCmdGenBusReq

### DIFF
--- a/hardware/buffers/BufferWriterCmdGenBusReq.vhd
+++ b/hardware/buffers/BufferWriterCmdGenBusReq.vhd
@@ -285,7 +285,7 @@ begin
   -----------------------------------------------------------------------------
   comb_proc : process (
     r,
-    cmdIn_valid, cmdIn_firstIdx, cmdIn_baseAddr, cmdIn_implicit,
+    cmdIn_valid, cmdIn_firstIdx, cmdIn_lastIdx, cmdIn_baseAddr, cmdIn_implicit,
     busReq_ready,
     byte_address,
     steps_last, steps_valid,


### PR DESCRIPTION
Fix a synthesis warning about `cmdIn_lastIdx` not being in the sensitivity list when read in `BufferWriterCmdGenBusReq`.