### PR TITLE
Fix clock assignments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
 
 project(fletcher)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 option(FLETCHER_BUILD_FLETCHGEN "Build fletchgen" OFF)
 option(FLETCHER_BUILD_ECHO "Build echo platform library" OFF)

--- a/codegen/cpp/fletchgen/CMakeLists.txt
+++ b/codegen/cpp/fletchgen/CMakeLists.txt
@@ -29,6 +29,7 @@ if(NOT cerata_POPULATED)
   set(BUILD_CERATA_TESTS OFF CACHE BOOL "")
   set(BUILD_CERATA_DOT ON CACHE BOOL "")
   set(BUILD_CERATA_VHDL ON CACHE BOOL "")
+  set(BUILD_CERATA_YAML ON CACHE BOOL "")
   add_subdirectory(${cerata_SOURCE_DIR} ${cerata_BINARY_DIR})
 endif()
 

--- a/codegen/cpp/fletchgen/src/fletchgen/array.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/array.cc
@@ -15,6 +15,7 @@
 #include "fletchgen/array.h"
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <fletcher/common.h>
 #include <utility>
 #include <memory>

--- a/codegen/cpp/fletchgen/src/fletchgen/basic_types.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/basic_types.cc
@@ -15,6 +15,7 @@
 #include "fletchgen/basic_types.h"
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <fletcher/common.h>
 
 #include <memory>
@@ -73,6 +74,7 @@ std::shared_ptr<Type> cr() {
   static std::shared_ptr<Type> result = record("cr", {
       field("clk", bit()),
       field("reset", bit())});
+  result->meta[cerata::vhdl::meta::NO_INSERT_SIGNAL] = "true";
   return result;
 }
 

--- a/codegen/cpp/fletchgen/src/fletchgen/bus.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/bus.cc
@@ -15,6 +15,7 @@
 #include "fletchgen/bus.h"
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 
 #include <memory>
 #include <vector>

--- a/codegen/cpp/fletchgen/src/fletchgen/design.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/design.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 
 #include <string>
 #include <vector>

--- a/codegen/cpp/fletchgen/src/fletchgen/fletchgen.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/fletchgen.cc
@@ -15,6 +15,8 @@
 #include "fletchgen/fletchgen.h"
 
 #include <cerata/api.h>
+#include <cerata/dot/dot.h>
+#include <cerata/vhdl/vhdl.h>
 #include <fletcher/common.h>
 
 #include <fstream>

--- a/codegen/cpp/fletchgen/src/fletchgen/mmio.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/mmio.cc
@@ -17,6 +17,7 @@
 #include <fletcher/fletcher.h>
 #include <fletcher/common.h>
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <memory>
 #include <string>
 #include <fstream>

--- a/codegen/cpp/fletchgen/src/fletchgen/nucleus.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/nucleus.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "fletchgen/nucleus.h"
-
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <vector>
 #include <string>
 #include <cerata/parameter.h>
 
+#include "fletchgen/nucleus.h"
 #include "fletchgen/basic_types.h"
 #include "fletchgen/recordbatch.h"
 #include "fletchgen/kernel.h"

--- a/codegen/cpp/fletchgen/src/fletchgen/profiler.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/profiler.cc
@@ -15,6 +15,7 @@
 #include "fletchgen/profiler.h"
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <cmath>
 #include <memory>
 #include <vector>

--- a/codegen/cpp/fletchgen/src/fletchgen/top/axi.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/top/axi.cc
@@ -15,6 +15,7 @@
 #include "fletchgen/top/axi.h"
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <memory>
 
 #include "fletchgen/top/axi_template.h"

--- a/codegen/cpp/fletchgen/src/fletchgen/top/sim.cc
+++ b/codegen/cpp/fletchgen/src/fletchgen/top/sim.cc
@@ -16,6 +16,7 @@
 
 #include <fletcher/fletcher.h>
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <string>
 #include <iomanip>
 #include <cstdlib>

--- a/codegen/cpp/fletchgen/test/fletchgen/test_types.cc
+++ b/codegen/cpp/fletchgen/test/fletchgen/test_types.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
 #include <gtest/gtest.h>
 #include <memory>
 

--- a/codegen/cpp/fletchgen/test/fletchgen/test_utils.h
+++ b/codegen/cpp/fletchgen/test/fletchgen/test_utils.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <cerata/api.h>
+#include <cerata/vhdl/vhdl.h>
+#include <cerata/dot/dot.h>
 #include <fstream>
 #include <string>
 #include <utility>


### PR DESCRIPTION
Cerata inserts signals between basically everything to prevent all sorts of annoying VHDL stuff from being a problem, but it shouldn't for clock signals.