### PR TITLE
Use env files in documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         mkdir -p $HOME/mdbook
         curl -L https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C $HOME/mdbook
-        echo "::add-path::${HOME}/mdbook/"
+        echo "${HOME}/mdbook/" >> $GITHUB_PATH
     - name: Build
       run: mdbook build
       working-directory: docs


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/