### PR TITLE
Check out vhlib submodule for pyfletchgen build

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -29,6 +29,8 @@ jobs:
         - 'cp38-cp38'
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Install Apache Arrow
       run: |
         yum install -y https://apache.bintray.com/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe)/apache-arrow-release-latest.rpm


### PR DESCRIPTION
pyfletchgen 0.0.14 is missing vhlib in its newly added set of VHDL resource files, because CI wasn't checking out the vhlib submodule.